### PR TITLE
Redesign the dot ledger: draining fixed grid with a live current-day gauge

### DIFF
--- a/Countdown/CountdownViewController.swift
+++ b/Countdown/CountdownViewController.swift
@@ -21,6 +21,7 @@ final class CountdownViewController: UIViewController {
     private let componentSet: Set<Calendar.Component> = [.day, .hour, .minute, .second]
 
     private var countdownDate = Date()
+    private var startDate = Date()               // when this countdown began — sizes the dot grid's total span
     private var style = VisualStyle.saved
     private var timer: Timer?
     private var didInitialRefill = false
@@ -59,6 +60,21 @@ final class CountdownViewController: UIViewController {
         return f
     }()
 
+    private let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"                            // 3:30 PM
+        return f
+    }()
+
+    /// A target at exactly 00:00 is treated as a pure calendar-day target:
+    /// showing "12:00 AM" there would be noise, so the time is only surfaced
+    /// when the user actually set one. Uses the current calendar/time zone so
+    /// "midnight" means midnight where the user is.
+    private func isMidnight(_ date: Date) -> Bool {
+        let c = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return (c.hour ?? 0) == 0 && (c.minute ?? 0) == 0
+    }
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
@@ -76,10 +92,27 @@ final class CountdownViewController: UIViewController {
         if let saved = defaults.object(forKey: "date") as? Date {
             countdownDate = saved
         }
+        // The dot grid drains over the whole span, so it needs to know when the
+        // countdown began. Existing installs (saved target, no start) seed to now
+        // → the grid starts full today and drains from here.
+        if let savedStart = defaults.object(forKey: "startDate") as? Date {
+            startDate = savedStart
+        } else {
+            defaults.set(startDate, forKey: "startDate")
+        }
 
         // Screenshot hook: seed a populated countdown (e.g. SIMCTL_CHILD_SEED_DAYS=64).
         if let seed = ProcessInfo.processInfo.environment["SEED_DAYS"], let d = Int(seed) {
-            countdownDate = Date().addingTimeInterval(TimeInterval(d * 86400 + 8 * 3600 + 39 * 60 + 16))
+            // Sub-day offset; SEED_SECS shrinks it so a rollover fires soon after
+            // launch (for capturing the dissolve animation).
+            let subDay = ProcessInfo.processInfo.environment["SEED_SECS"].flatMap(Int.init) ?? (8 * 3600 + 39 * 60 + 16)
+            countdownDate = Date().addingTimeInterval(TimeInterval(d * 86400 + subDay))
+            startDate = Date()                 // start = now so the seeded span shows a full grid
+            // Optional: backdate the start so the grid shows a partial drain
+            // (SIMCTL_CHILD_SEED_ELAPSED=20 → 20 days already emptied).
+            if let e = ProcessInfo.processInfo.environment["SEED_ELAPSED"], let elapsed = Int(e) {
+                startDate = Date().addingTimeInterval(TimeInterval(-elapsed * 86400))
+            }
         }
         // Screenshot hook: force a style (SIMCTL_CHILD_STYLE=editorial).
         if let forced = ProcessInfo.processInfo.environment["STYLE"].flatMap(VisualStyle.init) {
@@ -175,27 +208,19 @@ final class CountdownViewController: UIViewController {
         ])
     }
 
-    /// The dot ledger block, pinned above the bottom edge with its caption.
-    private func addDotLedger(captionColor: UIColor, accent: UIColor, stroke: UIColor) {
-        let caption = UILabel()
-        caption.font = .systemFont(ofSize: 11, weight: .semibold)
-        caption.textColor = captionColor
-        caption.setText("ONE DOT PER DAY", kern: 1.5)
-
+    /// The dot ledger block, pinned above the bottom edge.
+    private func addDotLedger(accent: UIColor, stroke: UIColor) {
         let ledger = DotLedgerView()
         ledger.accentColor = accent
         ledger.strokeColor = stroke
         dotLedger = ledger
 
-        [caption, ledger].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            styleRoot.addSubview($0)
-        }
+        ledger.translatesAutoresizingMaskIntoConstraints = false
+        styleRoot.addSubview(ledger)
         NSLayoutConstraint.activate([
             ledger.leadingAnchor.constraint(equalTo: styleRoot.leadingAnchor, constant: 32),
-            ledger.bottomAnchor.constraint(equalTo: styleRoot.bottomAnchor, constant: -56),
-            caption.leadingAnchor.constraint(equalTo: ledger.leadingAnchor),
-            caption.bottomAnchor.constraint(equalTo: ledger.topAnchor, constant: -12)
+            ledger.trailingAnchor.constraint(equalTo: styleRoot.trailingAnchor, constant: -32),
+            ledger.bottomAnchor.constraint(equalTo: styleRoot.bottomAnchor, constant: -56)
         ])
     }
 
@@ -288,16 +313,18 @@ final class CountdownViewController: UIViewController {
             $0.translatesAutoresizingMaskIntoConstraints = false
             styleRoot.addSubview($0)
         }
-        NSLayoutConstraint.activate([
-            days.topAnchor.constraint(equalTo: previousRow!.bottomAnchor, constant: 40),
-            days.leadingAnchor.constraint(equalTo: styleRoot.leadingAnchor, constant: 32),
-            caption.topAnchor.constraint(equalTo: days.bottomAnchor, constant: 6),
-            caption.leadingAnchor.constraint(equalTo: days.leadingAnchor)
-        ])
 
-        addDotLedger(captionColor: white.withAlphaComponent(0.35),
-                     accent: style.accent,
+        addDotLedger(accent: style.accent,
                      stroke: white.withAlphaComponent(0.28))
+
+        // The days block sits just above the dot grid (bottom-up), riding along
+        // as the grid's height changes with the day count.
+        NSLayoutConstraint.activate([
+            days.leadingAnchor.constraint(equalTo: styleRoot.leadingAnchor, constant: 32),
+            caption.leadingAnchor.constraint(equalTo: days.leadingAnchor),
+            caption.topAnchor.constraint(equalTo: days.bottomAnchor, constant: 6),
+            caption.bottomAnchor.constraint(equalTo: dotLedger!.topAnchor, constant: -20)
+        ])
     }
 
     // MARK: - Style 2 · Editorial
@@ -315,10 +342,14 @@ final class CountdownViewController: UIViewController {
         dial.selectedTickWidth = 2.5
         concentricDial = dial
 
-        // Dial center: serif days numeral over an SF "days" caption.
+        // Dial center: serif days numeral over an SF "days" caption. Big at 1–2
+        // digits; auto-shrinks so a 3-digit count doesn't crowd the inner ring.
         let days = UILabel()
         days.font = Fonts.serif(52, tabular: true)
         days.textColor = ink
+        days.textAlignment = .center
+        days.adjustsFontSizeToFitWidth = true
+        days.minimumScaleFactor = 0.55
         daysNumeralLabel = days
 
         let daysCaption = UILabel()
@@ -366,6 +397,8 @@ final class CountdownViewController: UIViewController {
 
             days.centerXAnchor.constraint(equalTo: dial.centerXAnchor),
             days.centerYAnchor.constraint(equalTo: dial.centerYAnchor, constant: -10),
+            days.widthAnchor.constraint(equalTo: dial.widthAnchor, multiplier: 0.26),  // keep the numeral inside the inner ring
+
             daysCaption.centerXAnchor.constraint(equalTo: dial.centerXAnchor),
             daysCaption.topAnchor.constraint(equalTo: days.bottomAnchor, constant: -2),
 
@@ -376,8 +409,7 @@ final class CountdownViewController: UIViewController {
             unitsRow.topAnchor.constraint(equalTo: until.bottomAnchor, constant: 28)
         ])
 
-        addDotLedger(captionColor: ink.withAlphaComponent(0.35),
-                     accent: style.accent,
+        addDotLedger(accent: style.accent,
                      stroke: ink.withAlphaComponent(0.35))
     }
 
@@ -526,7 +558,10 @@ final class CountdownViewController: UIViewController {
         let minutes = max(0, components.minute ?? 0)
         let seconds = max(0, components.second ?? 0)
 
-        let shortDate = shortDateFormatter.string(from: countdownDate).uppercased()
+        var shortDate = shortDateFormatter.string(from: countdownDate).uppercased()
+        if !isMidnight(countdownDate) {
+            shortDate += "  " + timeFormatter.string(from: countdownDate).uppercased()
+        }
 
         switch style {
         case .ledger:
@@ -537,7 +572,11 @@ final class CountdownViewController: UIViewController {
         case .editorial:
             headerDateLabel?.setText(shortDate, kern: 2.5)
             daysNumeralLabel?.text = "\(days)"
-            untilLabel?.text = "until \(longDateFormatter.string(from: countdownDate))"
+            var until = "until \(longDateFormatter.string(from: countdownDate))"
+            if !isMidnight(countdownDate) {
+                until += " at \(timeFormatter.string(from: countdownDate))"
+            }
+            untilLabel?.text = until
             concentricDial?.setValues(seconds: seconds, minutes: minutes, hours: hours, animated: animateRollovers)
             for (label, value) in zip(unitValueLabels, [hours, minutes, seconds]) { label.text = "\(value)" }
         case .tminus:
@@ -547,7 +586,14 @@ final class CountdownViewController: UIViewController {
             for (label, value) in zip(unitValueLabels, [hours, minutes, seconds]) { label.text = "\(value)" }
         }
 
-        dotLedger?.days = days
+        // Total span = whole journey from start to target; the grid holds that
+        // many dots: `days` solid, one current-day gauge, the rest elapsed.
+        // `dayFraction` is how much of the current day is still left, so the
+        // gauge on the leading dot depletes with the hours/minutes/seconds.
+        let spanDays = Calendar.current.dateComponents([.day], from: startDate, to: countdownDate).day ?? days
+        let totalDays = max(spanDays, days + 1, 1)          // +1 leaves room for the current-day dot
+        let dayFraction = CGFloat(hours * 3600 + minutes * 60 + seconds) / 86_400
+        dotLedger?.setValues(total: totalDays, wholeDays: days, dayFraction: dayFraction, animated: animateRollovers)
         updateBadge(days: days)          // keep the home-screen badge in step with the on-screen count
     }
 
@@ -610,6 +656,8 @@ extension CountdownViewController: SettingsSheetDelegate {
     func settingsSheet(_ sheet: SettingsSheetViewController, didPick date: Date) {
         countdownDate = date
         defaults.set(date, forKey: "date")
+        startDate = Date()                     // a freshly picked target restarts the span → grid fills up
+        defaults.set(startDate, forKey: "startDate")
         refresh(animateRollovers: false)       // update numerals now, without per-wheel-step volleys
         scheduleRefillVolley()                  // one clean sweep once the wheel settles
     }

--- a/Countdown/DotLedgerView.swift
+++ b/Countdown/DotLedgerView.swift
@@ -2,35 +2,50 @@
 //  DotLedgerView.swift
 //  Countdown
 //
-//  "One dot per day": a grid with one dot per remaining day, 16 columns.
-//  Day 0 (today) is a filled accent dot; the rest are stroked circles.
-//  Replaces the old DaysRingsView medallion grid in the redesigned styles.
+//  "One dot per day": a fixed grid holding every day of the countdown's span,
+//  16 columns. Whole remaining days are solid accent discs; the day currently
+//  in progress is highlighted as a gauge ring whose accent arc depletes with the
+//  fraction of today left; elapsed days are faint hollow rings. As a day fully
+//  drains the highlight steps to the next dot (a Dissolve cross-fade) and the
+//  emptied day settles into a hollow ring.
+//
+//  Layer-backed: each cell owns three CAShapeLayers (disc / track / gauge) whose
+//  opacities cross-fade between the three states, so a single dot animates its
+//  role change independently and the gauge sweeps every second.
 //
 
 import UIKit
 
 final class DotLedgerView: UIView {
 
-    var days: Int = 0 {
-        didSet {
-            guard days != oldValue else { return }
-            invalidateIntrinsicContentSize()
-            setNeedsDisplay()
-        }
-    }
-
-    var accentColor: UIColor = UIColor(hex: 0xBFE8FB) { didSet { setNeedsDisplay() } }
-    var strokeColor: UIColor = UIColor(white: 1, alpha: 0.28) { didSet { setNeedsDisplay() } }
+    var accentColor: UIColor = UIColor(hex: 0xBFE8FB) { didSet { applyColors() } }
+    var strokeColor: UIColor = UIColor(white: 1, alpha: 0.28) { didSet { applyColors() } }
 
     private let columns = 16
-    private let maxRows = 6                     // caps the grid height; longer counts show an overflow marker
-    private let cell: CGFloat = 19
+    private let maxRows = 9                      // caps the grid height (9 × 16 = 144-day capacity)
+    private let cell: CGFloat = 19               // vertical pitch (row height)
     private let dotRadiusRatio: CGFloat = 0.22
     private let strokeWidth: CGFloat = 1.1
+    private let gaugeWidth: CGFloat = 1.8        // the accent arc reads a touch bolder than the faint track
+    private let dissolveDuration = 0.5
 
-    /// Dots that fit before the grid is capped (the last one becomes the
-    /// "more beyond" marker when the countdown exceeds this).
+    /// Three marks per grid cell. Their opacities express the state:
+    ///   solid day → disc; current day → track + gauge; elapsed day → track.
+    private struct Dot {
+        let disc: CAShapeLayer     // filled accent disc  (a whole day remaining)
+        let track: CAShapeLayer    // faint full ring     (current day's day-track / an elapsed day)
+        let gauge: CAShapeLayer    // accent arc          (fraction of the current day left)
+    }
+    private var dots: [Dot] = []
+    private var overflowMarker: CAShapeLayer?     // accent ellipsis when more days remain than the grid can hold
+
+    private var total = 0                         // days in the whole span (grid size)
+    private var wholeDays = 0                     // fully-remaining days → solid discs
+    private var dayFraction: CGFloat = 0          // fraction of the current day still left (1…0)
+
     private var capacity: Int { maxRows * columns }
+    private var visibleCount: Int { min(max(total, 1), capacity) }
+    private var currentIndex: Int { wholeDays }   // the highlighted "today" dot sits just past the solid days
 
     override init(frame: CGRect) { super.init(frame: frame); commonInit() }
     required init?(coder: NSCoder) { super.init(coder: coder); commonInit() }
@@ -38,45 +53,220 @@ final class DotLedgerView: UIView {
     private func commonInit() {
         backgroundColor = .clear
         isOpaque = false
-        contentMode = .redraw
+    }
+
+    /// Seeds or advances the grid. `total` sizes it, `wholeDays` is the solid
+    /// count, `dayFraction` fills the current dot's gauge. Only dots whose role
+    /// changes animate; the per-second gauge sweep is silent.
+    func setValues(total: Int, wholeDays: Int, dayFraction: CGFloat, animated: Bool) {
+        let newTotal = max(total, 1)
+        let newWhole = min(max(wholeDays, 0), newTotal)
+        let totalChanged = newTotal != self.total
+        self.total = newTotal
+        self.wholeDays = newWhole
+        self.dayFraction = min(max(dayFraction, 0), 1)
+
+        if totalChanged {
+            invalidateIntrinsicContentSize()
+            rebuildLayers()
+            applyStates(animated: false)         // fresh layers seed instantly
+        } else {
+            applyStates(animated: animated)
+        }
     }
 
     override var intrinsicContentSize: CGSize {
-        let neededRows = Int(ceil(Double(max(days, 1)) / Double(columns)))
-        let rows = max(1, min(neededRows, maxRows))     // never taller than the cap
+        let neededRows = Int(ceil(Double(max(total, 1)) / Double(columns)))
+        let rows = max(1, min(neededRows, maxRows))
         return CGSize(width: CGFloat(columns) * cell, height: CGFloat(rows) * cell)
     }
 
-    override func draw(_ rect: CGRect) {
-        let n = max(days, 1)                       // today is always a dot
-        let overflow = n > capacity                // more days than the grid can hold
-        let visible = overflow ? capacity : n
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layoutDots()
+    }
+
+    // MARK: - Layer lifecycle
+
+    private func rebuildLayers() {
+        dots.forEach { $0.disc.removeFromSuperlayer(); $0.track.removeFromSuperlayer(); $0.gauge.removeFromSuperlayer() }
+        dots.removeAll()
+        overflowMarker?.removeFromSuperlayer()
+        overflowMarker = nil
+
+        for _ in 0..<visibleCount {
+            let track = CAShapeLayer()
+            track.fillColor = UIColor.clear.cgColor
+            track.strokeColor = strokeColor.cgColor
+            track.lineWidth = strokeWidth
+
+            let gauge = CAShapeLayer()
+            gauge.fillColor = UIColor.clear.cgColor
+            gauge.strokeColor = accentColor.cgColor
+            gauge.lineWidth = gaugeWidth
+            gauge.lineCap = .round
+            gauge.strokeStart = 0
+
+            let disc = CAShapeLayer()
+            disc.fillColor = accentColor.cgColor
+
+            layer.addSublayer(track)             // faint track underneath
+            layer.addSublayer(gauge)             // accent arc over the track
+            layer.addSublayer(disc)              // solid disc on top when it's a whole day
+            dots.append(Dot(disc: disc, track: track, gauge: gauge))
+        }
+
+        let marker = CAShapeLayer()
+        marker.fillColor = accentColor.cgColor
+        marker.opacity = 0
+        layer.addSublayer(marker)
+        overflowMarker = marker
+
+        layoutDots()
+    }
+
+    /// Each dot is its own cell-sized layer centered on its grid slot. The gauge
+    /// path is a full circle starting at 12 o'clock going clockwise, so
+    /// `strokeEnd = fraction` draws the remaining slice like a depleting clock.
+    private func layoutDots() {
+        guard !dots.isEmpty, bounds.width > 0 else { return }
+
+        let colPitch = bounds.width / CGFloat(columns)   // fill the pinned width evenly
         let r = dotRadiusRatio * cell
+        let ringR = r - strokeWidth / 2
+        let side = cell
+        let mid = CGPoint(x: side / 2, y: side / 2)
 
-        for i in 0..<visible {
-            let cx = CGFloat(i % columns) * cell + cell / 2
-            let cy = CGFloat(i / columns) * cell + cell / 2
+        let discPath = UIBezierPath(arcCenter: mid, radius: r,
+                                    startAngle: 0, endAngle: 2 * .pi, clockwise: true).cgPath
+        let ringPath = UIBezierPath(arcCenter: mid, radius: ringR,
+                                    startAngle: 0, endAngle: 2 * .pi, clockwise: true).cgPath
+        let gaugePath = UIBezierPath(arcCenter: mid, radius: ringR,
+                                     startAngle: -.pi / 2, endAngle: -.pi / 2 + 2 * .pi,
+                                     clockwise: true).cgPath
 
-            if overflow && i == visible - 1 {
-                // Terminal cell: an accent ellipsis meaning "…more beyond".
-                accentColor.setFill()
-                for k in -1...1 {
-                    let d = UIBezierPath(arcCenter: CGPoint(x: cx + CGFloat(k) * 3.4, y: cy), radius: 1.2,
-                                         startAngle: 0, endAngle: 2 * .pi, clockwise: true)
-                    d.fill()
-                }
-            } else if i == 0 {
-                let dot = UIBezierPath(arcCenter: CGPoint(x: cx, y: cy), radius: r,
-                                       startAngle: 0, endAngle: 2 * .pi, clockwise: true)
-                accentColor.setFill()
-                dot.fill()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for (i, dot) in dots.enumerated() {
+            let cx = colPitch * (CGFloat(i % columns) + 0.5)
+            let cy = cell * (CGFloat(i / columns) + 0.5)
+            let frame = CGRect(x: cx - side / 2, y: cy - side / 2, width: side, height: side)
+            dot.disc.frame = frame;  dot.disc.path = discPath
+            dot.track.frame = frame; dot.track.path = ringPath
+            dot.gauge.frame = frame; dot.gauge.path = gaugePath
+        }
+
+        if let marker = overflowMarker, visibleCount > 0 {
+            let i = visibleCount - 1                       // marker lives in the last cell
+            let cx = colPitch * (CGFloat(i % columns) + 0.5)
+            let cy = cell * (CGFloat(i / columns) + 0.5)
+            marker.frame = CGRect(x: cx - side / 2, y: cy - side / 2, width: side, height: side)
+            let dotR: CGFloat = 1.3, gap: CGFloat = 3.6    // "…more beyond" ellipsis
+            let ellipsis = UIBezierPath()
+            for k in -1...1 {
+                ellipsis.append(UIBezierPath(arcCenter: CGPoint(x: mid.x + CGFloat(k) * gap, y: mid.y),
+                                             radius: dotR, startAngle: 0, endAngle: 2 * .pi, clockwise: true))
+            }
+            marker.path = ellipsis.cgPath
+        }
+        CATransaction.commit()
+    }
+
+    // MARK: - State
+
+    private enum Role { case solid, current, elapsed }
+
+    private func role(of index: Int) -> Role {
+        if index < wholeDays { return .solid }
+        if index == currentIndex && dayFraction > 0.0001 { return .current }
+        return .elapsed
+    }
+
+    private func applyStates(animated: Bool) {
+        // Overflow: more remaining days than the grid can show → fill all but the
+        // last cell with solid discs and mark the last as "…more beyond". Gated on
+        // the (shrinking) remaining count, so it clears when the countdown enters
+        // the final window and precise draining begins.
+        let overflow = visibleCount > 0 && wholeDays >= visibleCount
+        let markerIndex = visibleCount - 1
+
+        for (i, dot) in dots.enumerated() {
+            let discTarget: Float, trackTarget: Float, gaugeTarget: Float
+            if overflow {
+                discTarget = i < markerIndex ? 1 : 0     // last cell hosts the marker instead of a disc
+                trackTarget = 0
+                gaugeTarget = 0
             } else {
-                let dot = UIBezierPath(arcCenter: CGPoint(x: cx, y: cy), radius: r - strokeWidth / 2,
-                                       startAngle: 0, endAngle: 2 * .pi, clockwise: true)
-                dot.lineWidth = strokeWidth
-                strokeColor.setStroke()
-                dot.stroke()
+                switch role(of: i) {
+                case .solid:   discTarget = 1; trackTarget = 0; gaugeTarget = 0
+                case .current: discTarget = 0; trackTarget = 1; gaugeTarget = 1
+                case .elapsed: discTarget = 0; trackTarget = 1; gaugeTarget = 0
+                }
+            }
+
+            // The gauge sweep itself is silent every second; only role changes fade.
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            dot.gauge.strokeEnd = gaugeTarget == 1 ? dayFraction : 0
+            CATransaction.commit()
+
+            let changed = dot.disc.opacity != discTarget
+                || dot.track.opacity != trackTarget
+                || dot.gauge.opacity != gaugeTarget
+            if animated && changed {
+                let discWasSolid = dot.disc.opacity == 1
+                fade(dot.disc, to: discTarget)
+                fade(dot.track, to: trackTarget)
+                fade(dot.gauge, to: gaugeTarget)
+                // Scale flourish as a solid day dissolves into the gauge ring.
+                if discTarget == 0 && discWasSolid {
+                    let scale = CABasicAnimation(keyPath: "transform.scale")
+                    scale.fromValue = 1.0
+                    scale.toValue = 0.6
+                    scale.duration = dissolveDuration
+                    scale.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                    dot.disc.add(scale, forKey: "dissolveScale")
+                }
+            } else {
+                CATransaction.begin()
+                CATransaction.setDisableActions(true)
+                dot.disc.opacity = discTarget
+                dot.track.opacity = trackTarget
+                dot.gauge.opacity = gaugeTarget
+                CATransaction.commit()
             }
         }
+
+        if let marker = overflowMarker {
+            let target: Float = overflow ? 1 : 0
+            if animated && marker.opacity != target {
+                fade(marker, to: target)
+            } else {
+                CATransaction.begin()
+                CATransaction.setDisableActions(true)
+                marker.opacity = target
+                CATransaction.commit()
+            }
+        }
+    }
+
+    private func fade(_ layer: CAShapeLayer, to target: Float) {
+        guard layer.opacity != target else { return }
+        let fade = CABasicAnimation(keyPath: "opacity")
+        fade.fromValue = layer.presentation()?.opacity ?? layer.opacity
+        fade.toValue = target
+        fade.duration = dissolveDuration
+        fade.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        layer.opacity = target                    // commit the model value
+        layer.add(fade, forKey: "dissolveFade")
+    }
+
+    private func applyColors() {
+        for dot in dots {
+            dot.disc.fillColor = accentColor.cgColor
+            dot.gauge.strokeColor = accentColor.cgColor
+            dot.track.strokeColor = strokeColor.cgColor
+        }
+        overflowMarker?.fillColor = accentColor.cgColor
     }
 }

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,29 @@
+# Design prototypes
+
+Interactive design studies for the Countdown app. Open the `.html` files in any browser.
+
+## dot-rollover-transitions.html
+
+Explores how the "one dot per day" ledger (`DotLedgerView`) should behave when a
+day rolls over. Moves the grid from a **subtractive** model (dots are removed as
+days pass) to a **fixed-grid** model (every day of the span has a stable dot that
+changes state).
+
+Four transition treatments are shown side by side: **Dissolve**, **Ring draw**,
+**Flip**, **Ripple**, plus a direction toggle (empty-as-days-pass vs
+fill-as-days-pass).
+
+### Decision (2026-07-13)
+
+- **Direction:** *Empty as days pass* — the grid starts full and drains, reading
+  as spending a finite reserve of days.
+- **Transition:** *Dissolve* — a calm opacity/scale cross-fade between the filled
+  and hollow states. Chosen for an ambient, always-on countdown.
+
+### Implementation note
+
+`DotLedgerView` currently receives only `days` (days remaining). The fixed-grid
+model needs a **second input — the total span** (e.g. days from countdown
+creation to the target date) so it can draw `total` dots and know which are
+filled. Animating individual dots will likely mean moving from `draw(_:)` to
+per-dot `CAShapeLayer`s, since Core Graphics can't animate individual dots.

--- a/design/dot-rollover-transitions.html
+++ b/design/dot-rollover-transitions.html
@@ -1,0 +1,309 @@
+<title>Dot rollover — fill & empty transitions</title>
+<style>
+  :root {
+    --paper: #EDE8DC;
+    --panel: #F3EFE6;
+    --ink: #26241F;
+    --ink-soft: #6b665c;
+    --hollow: rgba(38, 36, 31, 0.26);
+    --fill: #3B4A6B;
+    --accent: #B4563C;
+    --rule: rgba(38, 36, 31, 0.12);
+    --shadow: rgba(38, 36, 31, 0.10);
+    --btn-ink: #26241F;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #1a1917; --panel: #211f1c; --ink: #ECE7DB; --ink-soft: #9c968a;
+      --hollow: rgba(236, 231, 219, 0.24); --fill: #9DB4E6; --accent: #E08762;
+      --rule: rgba(236, 231, 219, 0.14); --shadow: rgba(0, 0, 0, 0.4); --btn-ink: #ECE7DB;
+    }
+  }
+  :root[data-theme="light"] {
+    --paper: #EDE8DC; --panel: #F3EFE6; --ink: #26241F; --ink-soft: #6b665c;
+    --hollow: rgba(38,36,31,0.26); --fill: #3B4A6B; --accent: #B4563C;
+    --rule: rgba(38,36,31,0.12); --shadow: rgba(38,36,31,0.10); --btn-ink: #26241F;
+  }
+  :root[data-theme="dark"] {
+    --paper: #1a1917; --panel: #211f1c; --ink: #ECE7DB; --ink-soft: #9c968a;
+    --hollow: rgba(236,231,219,0.24); --fill: #9DB4E6; --accent: #E08762;
+    --rule: rgba(236,231,219,0.14); --shadow: rgba(0,0,0,0.4); --btn-ink: #ECE7DB;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 44px 24px 80px; }
+  .eyebrow {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-soft); margin: 0 0 14px;
+  }
+  h1 {
+    font-size: clamp(24px, 4.5vw, 33px); line-height: 1.14; font-weight: 600;
+    letter-spacing: -0.01em; text-wrap: balance; margin: 0 0 14px;
+  }
+  .lede { font-size: 16px; color: var(--ink-soft); margin: 0 0 30px; max-width: 60ch; }
+
+  /* ---- control bar ---- */
+  .bar {
+    position: sticky; top: 0; z-index: 5;
+    display: flex; flex-wrap: wrap; align-items: center; gap: 14px 18px;
+    padding: 16px; margin-bottom: 30px;
+    background: var(--panel); border: 1px solid var(--rule); border-radius: 14px;
+    box-shadow: 0 1px 0 var(--shadow);
+  }
+  .readout {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-variant-numeric: tabular-nums; font-size: 13.5px; color: var(--ink-soft);
+  }
+  .readout b { color: var(--fill); font-weight: 700; }
+  .spacer { flex: 1 1 auto; }
+  button {
+    font: inherit; font-size: 14px; font-weight: 550;
+    color: var(--panel); background: var(--btn-ink);
+    border: none; border-radius: 9px; padding: 9px 16px; cursor: pointer;
+    transition: opacity .15s ease, transform .06s ease;
+  }
+  button:hover { opacity: .88; }
+  button:active { transform: translateY(1px); }
+  button.ghost { color: var(--ink); background: transparent; border: 1px solid var(--rule); }
+  button:focus-visible { outline: 2px solid var(--fill); outline-offset: 2px; }
+
+  .seg {
+    display: inline-flex; border: 1px solid var(--rule); border-radius: 9px; overflow: hidden;
+  }
+  .seg button {
+    border-radius: 0; background: transparent; color: var(--ink-soft);
+    font-size: 13px; font-weight: 550; padding: 8px 14px;
+  }
+  .seg button[aria-pressed="true"] { background: var(--fill); color: #fff; }
+  @media (prefers-color-scheme: dark) { .seg button[aria-pressed="true"] { color: #14130f; } }
+
+  /* ---- grid of demo panels ---- */
+  .demos { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  @media (max-width: 640px) { .demos { grid-template-columns: 1fr; } }
+  .demo {
+    background: var(--panel); border: 1px solid var(--rule);
+    border-radius: 14px; padding: 20px 20px 18px; box-shadow: 0 1px 0 var(--shadow);
+  }
+  .demo h2 {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; letter-spacing: 0.06em; text-transform: uppercase;
+    margin: 0 0 3px; color: var(--ink);
+  }
+  .demo p { font-size: 13px; color: var(--ink-soft); margin: 0 0 16px; min-height: 2.6em; }
+  svg { display: block; width: 100%; height: auto; overflow: visible; }
+  circle { transform-box: fill-box; transform-origin: center; }
+  circle.ring { fill: none; stroke: var(--hollow); stroke-width: 1.5; }
+  circle.fill { fill: var(--fill); stroke: none; }
+
+  .note {
+    margin-top: 34px; font-size: 14px; color: var(--ink-soft);
+    border-left: 2px solid var(--rule); padding-left: 16px; max-width: 62ch;
+  }
+  .note b { color: var(--ink); font-weight: 600; }
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">DotLedgerView · transition studies</p>
+  <h1>One dot per day, on a fixed grid — filling and emptying.</h1>
+  <p class="lede">
+    The grid now holds every day of the span at a fixed position. A rollover doesn’t add or remove a dot —
+    it flips one dot’s state. Four transition treatments react to the same “advance a day” below;
+    pick a direction and step through it.
+  </p>
+
+  <div class="bar">
+    <span class="readout"><b id="rDone">24</b> elapsed · <b id="rLeft">40</b> left · <span id="rTot">64</span> total</span>
+    <div class="spacer"></div>
+    <div class="seg" role="group" aria-label="Direction">
+      <button id="dirEmpty" aria-pressed="true">Empty as days pass</button>
+      <button id="dirFill" aria-pressed="false">Fill as days pass</button>
+    </div>
+    <button id="advance">Advance a day →</button>
+    <button id="reset" class="ghost">Reset</button>
+  </div>
+
+  <div class="demos" id="demos"></div>
+
+  <p class="note">
+    All four share one grid model — a dot is filled or hollow purely from its index vs. the day count, so
+    the state is always correct even if you skip the animation. The variations differ only in <b>timing</b>,
+    not geometry: same two circles per dot, different choreography. Tell me which feel is right and I’ll wire
+    that one into <b>DotLedgerView</b>, which needs the countdown’s <b>total span</b> as a new input.
+  </p>
+</div>
+
+<script>
+  const COLUMNS = 16, ROWS = 4, TOTAL = COLUMNS * ROWS;   // 64-dot grid
+  const PITCH = 20, R = 4.4, PAD = 4;
+  const NS = 'http://www.w3.org/2000/svg';
+  const CIRC = 2 * Math.PI * R;
+  const reduce = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const VARIATIONS = [
+    { key: 'dissolve', name: 'Dissolve', blurb: 'Fill and ring cross-fade with a soft scale. Calm and unfussy — the quiet default.' },
+    { key: 'ring',     name: 'Ring draw', blurb: 'The hollow ring strokes itself on around the edge as the fill fades. Precise, instrument-like.' },
+    { key: 'flip',     name: 'Flip', blurb: 'The dot squashes to a line and swaps faces — like flipping a tile or coin. Tactile.' },
+    { key: 'ripple',   name: 'Ripple', blurb: 'The changed dot pops and nudges its neighbors in a staggered wave. Emphasizes the moment.' },
+  ];
+
+  // ---- state ----
+  // Chosen direction for the app: "empty as days pass" (drain). Preferred
+  // transition: Dissolve. The other three variations are kept for reference.
+  let elapsed = 24;
+  let direction = 'empty';   // 'empty' = drain filled dots; 'fill' = fill from empty
+  const panels = [];         // { key, dots:[{ring,fill,col,row}] }
+
+  function isFilled(i) {
+    return direction === 'empty' ? i < (TOTAL - elapsed) : i < elapsed;
+  }
+  // index that changes when we advance one day, and its resulting state
+  function changeSpec() {
+    if (direction === 'empty') return { index: TOTAL - elapsed - 1, toFilled: false };
+    return { index: elapsed, toFilled: true };
+  }
+
+  function buildPanels() {
+    const host = document.getElementById('demos');
+    host.innerHTML = '';
+    panels.length = 0;
+    const w = COLUMNS * PITCH + PAD * 2, h = ROWS * PITCH + PAD * 2;
+
+    for (const v of VARIATIONS) {
+      const card = document.createElement('div');
+      card.className = 'demo';
+      card.innerHTML = `<h2>${v.name}</h2><p>${v.blurb}</p>`;
+      const svg = document.createElementNS(NS, 'svg');
+      svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+      svg.setAttribute('role', 'img');
+      svg.setAttribute('aria-label', `${v.name} transition demo`);
+      card.appendChild(svg);
+      host.appendChild(card);
+
+      const dots = [];
+      for (let i = 0; i < TOTAL; i++) {
+        const col = i % COLUMNS, row = Math.floor(i / COLUMNS);
+        const cx = PAD + col * PITCH + PITCH / 2;
+        const cy = PAD + row * PITCH + PITCH / 2;
+        const ring = document.createElementNS(NS, 'circle');
+        ring.setAttribute('class', 'ring');
+        ring.setAttribute('cx', cx); ring.setAttribute('cy', cy); ring.setAttribute('r', R);
+        const fill = document.createElementNS(NS, 'circle');
+        fill.setAttribute('class', 'fill');
+        fill.setAttribute('cx', cx); fill.setAttribute('cy', cy); fill.setAttribute('r', R);
+        svg.appendChild(ring); svg.appendChild(fill);
+        const filled = isFilled(i);
+        ring.style.opacity = filled ? 0 : 1;
+        fill.style.opacity = filled ? 1 : 0;
+        dots.push({ ring, fill, col, row });
+      }
+      panels.push({ key: v.key, dots });
+    }
+  }
+
+  function commitAll() {
+    for (const p of panels)
+      p.dots.forEach((d, i) => {
+        const f = isFilled(i);
+        d.ring.style.opacity = f ? 0 : 1;
+        d.fill.style.opacity = f ? 1 : 0;
+        d.ring.style.strokeDashoffset = ''; d.ring.style.strokeDasharray = '';
+        d.ring.style.transform = ''; d.fill.style.transform = '';
+      });
+    updateReadout();
+  }
+
+  function updateReadout() {
+    document.getElementById('rDone').textContent = elapsed;
+    document.getElementById('rLeft').textContent = TOTAL - elapsed;
+    document.getElementById('rTot').textContent = TOTAL;
+  }
+
+  // ---- per-variation animation of one dot ----
+  function animateDot(panel, index, toFilled) {
+    const d = panel.dots[index];
+    if (!d) return;
+    const ringTo = toFilled ? 0 : 1, fillTo = toFilled ? 1 : 0;
+    const ringFrom = toFilled ? 1 : 0, fillFrom = toFilled ? 0 : 1;
+    // commit final resting state (animation plays over it, then reverts to this)
+    d.ring.style.opacity = ringTo; d.fill.style.opacity = fillTo;
+
+    if (reduce()) return;
+    const ease = 'cubic-bezier(.2,.7,.2,1)';
+
+    if (panel.key === 'dissolve') {
+      d.fill.animate([{ opacity: fillFrom, transform: 'scale(.35)' }, { opacity: fillTo, transform: 'scale(1)' }],
+        { duration: 460, easing: ease });
+      d.ring.animate([{ opacity: ringFrom }, { opacity: ringTo }], { duration: 460, easing: ease });
+
+    } else if (panel.key === 'ring') {
+      // ring draws on/off via dashoffset; fill quick-fades
+      d.ring.style.strokeDasharray = CIRC;
+      const from = toFilled ? 0 : CIRC, to = toFilled ? CIRC : 0; // empty => draw ring in
+      d.ring.animate([{ opacity: 1, strokeDashoffset: from }, { opacity: ringTo === 0 ? 0 : 1, strokeDashoffset: to }],
+        { duration: 620, easing: 'ease-in-out' })
+        .onfinish = () => { d.ring.style.strokeDasharray = ''; d.ring.style.strokeDashoffset = ''; };
+      d.fill.animate([{ opacity: fillFrom }, { opacity: fillTo }], { duration: 300, easing: 'ease' });
+
+    } else if (panel.key === 'flip') {
+      // opacity swaps at the mid-point of the squash, so faces trade while edge-on
+      const opac = (from, to) => [
+        { opacity: from, offset: 0 }, { opacity: from, offset: 0.49 },
+        { opacity: to, offset: 0.51 }, { opacity: to, offset: 1 },
+      ];
+      const squash = [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0.05)', offset: 0.5 }, { transform: 'scaleX(1)' }];
+      const opt = { duration: 520, easing: 'ease-in-out' };
+      d.fill.animate(squash, opt); d.ring.animate(squash, opt);
+      d.fill.animate(opac(fillFrom, fillTo), opt);
+      d.ring.animate(opac(ringFrom, ringTo), opt);
+
+    } else if (panel.key === 'ripple') {
+      d.fill.animate([{ opacity: fillFrom }, { opacity: fillTo }], { duration: 380, easing: ease });
+      d.ring.animate([{ opacity: ringFrom }, { opacity: ringTo }], { duration: 380, easing: ease });
+      // pop the changed dot, then ripple neighbors by grid distance
+      const pop = [{ transform: 'scale(1)' }, { transform: 'scale(1.45)', offset: 0.4 }, { transform: 'scale(1)' }];
+      d.fill.animate(pop, { duration: 420, easing: ease });
+      d.ring.animate(pop, { duration: 420, easing: ease });
+      const c0 = d.col, r0 = d.row;
+      panel.dots.forEach((n, j) => {
+        if (j === index) return;
+        const dist = Math.abs(n.col - c0) + Math.abs(n.row - r0);
+        if (dist === 0 || dist > 3) return;
+        const el = isFilled(j) ? n.fill : n.ring;
+        el.animate([{ transform: 'scale(1)' }, { transform: 'scale(1.22)', offset: 0.5 }, { transform: 'scale(1)' }],
+          { duration: 340, delay: dist * 70, easing: ease });
+      });
+    }
+  }
+
+  function advance() {
+    if (direction === 'empty' && elapsed >= TOTAL) return;
+    if (direction === 'fill' && elapsed >= TOTAL) return;
+    const { index, toFilled } = changeSpec();
+    if (index < 0 || index >= TOTAL) { return; }
+    elapsed = Math.min(TOTAL, elapsed + 1);
+    for (const p of panels) animateDot(p, index, toFilled);
+    updateReadout();
+  }
+
+  // ---- wiring ----
+  document.getElementById('advance').addEventListener('click', advance);
+  document.getElementById('reset').addEventListener('click', () => { elapsed = 24; commitAll(); });
+  const bEmpty = document.getElementById('dirEmpty'), bFill = document.getElementById('dirFill');
+  function setDir(dir) {
+    direction = dir;
+    bEmpty.setAttribute('aria-pressed', dir === 'empty');
+    bFill.setAttribute('aria-pressed', dir === 'fill');
+    commitAll();
+  }
+  bEmpty.addEventListener('click', () => setDir('empty'));
+  bFill.addEventListener('click', () => setDir('fill'));
+
+  buildPanels();
+  updateReadout();
+</script>


### PR DESCRIPTION
## Summary
Reworks the "one dot per day" ledger from a **subtractive** grid (dots removed as days pass) to a **fixed grid of the whole span that drains**:

- **Whole remaining days** → solid accent discs
- **Current day** → highlighted gauge **ring** whose accent arc depletes with the hours/minutes/seconds left (same color as the discs — distinguished by its ring form)
- **Elapsed days** → faint hollow rings
- **Rollovers** cross-fade via a Dissolve animation; the current-day gauge sweeps every second
- **Overflow** (more days than fit) shows a "…more beyond" accent ellipsis; capacity is **9×16 = 144**

### Also in this PR
- Persist a **start date** so the grid knows the total span (existing installs seed to now). Adds `SEED_ELAPSED` / `SEED_SECS` screenshot hooks for QA.
- **Ledger layout:** move the "days remaining" block to just above the grid; drop the "ONE DOT PER DAY" caption (also removed from Editorial, which shares the view).
- **Editorial dial:** auto-shrink the days numeral so 3-digit counts (e.g. "109") don't crowd the inner tick ring; 1–2 digits stay full size.
- Prototypes + design notes under `design/`.

### Implementation notes
Moved `DotLedgerView` from Core Graphics `draw(_:)` to layer-backed rendering (three `CAShapeLayer`s per dot: disc / track / gauge) so individual dots animate their state independently.

### Verified
Built and exercised in the simulator: full grid, partial drain, live day rollover, 140-day (9-row) layout, 144+ overflow ellipsis, and the Editorial 109-vs-44 numeral sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
