### PR TITLE
Separate tap animation settings from refill behavior

### DIFF
--- a/Countdown/ConcentricDialView.swift
+++ b/Countdown/ConcentricDialView.swift
@@ -29,6 +29,10 @@ final class ConcentricDialView: UIView {
     var tickWidth: CGFloat = 1.9 { didSet { setNeedsDisplay() } }
     var selectedTickWidth: CGFloat = 2.5 { didSet { setNeedsDisplay() } }
 
+    /// Animation played when the dial is tapped. A concentric dial treats all
+    /// three rings as one control, so a tap replays every ring together.
+    var tapAnimation: DialAnimation = DialAnimationSettings.tap
+
     // Concentric geometry as fractions of the dial size (design tokens).
     private let bandRatio: CGFloat = 0.08
     private let gapRatio: CGFloat = 0.032
@@ -48,9 +52,8 @@ final class ConcentricDialView: UIView {
         let new = [seconds, minutes, hours]
         guard new != values else { return }
         if animated {
-            for k in 0..<3 where new[k] > values[k] {
-                volleyStarts[k] = window != nil ? CACurrentMediaTime() : nil
-            }
+            let rolledOver = (0..<3).filter { new[$0] > values[$0] }
+            play(DialAnimationSettings.refill, on: rolledOver)
         }
         values = new
         if volleyStarts.contains(where: { $0 != nil }) { ensureLink() }
@@ -59,9 +62,18 @@ final class ConcentricDialView: UIView {
 
     /// Volley-refill every ring (on appear / date change).
     func refillAll() {
-        guard window != nil else { volleyStarts = [nil, nil, nil]; setNeedsDisplay(); return }
+        play(DialAnimationSettings.refill, on: Array(0..<3))
+    }
+
+    private func startLaunchVolley(on rings: [Int]) {
+        guard !rings.isEmpty else { return }
+        guard window != nil else {
+            rings.forEach { volleyStarts[$0] = nil }
+            setNeedsDisplay()
+            return
+        }
         let now = CACurrentMediaTime()
-        volleyStarts = [now, now, now]
+        rings.forEach { volleyStarts[$0] = now }
         ensureLink()
         setNeedsDisplay()
     }
@@ -75,6 +87,7 @@ final class ConcentricDialView: UIView {
         backgroundColor = .clear
         isOpaque = false
         contentMode = .redraw
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapDial)))
     }
 
     deinit { link?.invalidate() }
@@ -82,6 +95,16 @@ final class ConcentricDialView: UIView {
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         if newWindow == nil { link?.invalidate(); link = nil }
+    }
+
+    @objc private func didTapDial() {
+        play(tapAnimation, on: Array(0..<3))
+    }
+
+    private func play(_ animation: DialAnimation, on rings: [Int]) {
+        switch animation {
+        case .launchVolley: startLaunchVolley(on: rings)
+        }
     }
 
     // MARK: - Display link

--- a/Countdown/SettingsSheetViewController.swift
+++ b/Countdown/SettingsSheetViewController.swift
@@ -3,7 +3,7 @@
 //  Countdown
 //
 //  The unified settings sheet: style picker (three preview cards), the
-//  target-date wheels and the (informational) refill-animation row, all in
+//  target-date wheels and animation settings, all in
 //  one UISheetPresentationController bottom sheet. Replaces the old gear
 //  menu and the inline bottom date picker.
 //
@@ -124,31 +124,25 @@ final class SettingsSheetViewController: UIViewController {
         picker.date = initialDate
         picker.addTarget(self, action: #selector(dateChanged(_:)), for: .valueChanged)
 
-        // Refill animation row — informational; the volley is the single
-        // shipped animation (the old 6-style list is retired).
-        let refillRow = UIView()
-        refillRow.backgroundColor = Palette.surface
-        refillRow.layer.cornerRadius = 12
-        refillRow.layer.borderWidth = 1
-        refillRow.layer.borderColor = Palette.border.cgColor
+        // Only Launch volley ships today, so these are informational for now.
+        // The choices are modeled separately so Tap can become independently
+        // selectable as soon as another animation is added.
+        let animationCaption = sectionCaption("ANIMATION")
+        let animationRows = UIStackView(arrangedSubviews: [
+            animationRow(label: "Refill", value: DialAnimationSettings.refill.title),
+            animationRow(label: "Tap", value: DialAnimationSettings.tap.title)
+        ])
+        animationRows.axis = .vertical
+        animationRows.spacing = 1 / UIScreen.main.scale
+        animationRows.backgroundColor = Palette.border
+        animationRows.layer.cornerRadius = 12
+        animationRows.layer.borderWidth = 1
+        animationRows.layer.borderColor = Palette.border.cgColor
+        animationRows.layer.masksToBounds = true
 
-        let refillLabel = UILabel()
-        refillLabel.text = "Refill animation"
-        refillLabel.font = .systemFont(ofSize: 14)
-        refillLabel.textColor = Palette.secondaryText
-
-        let refillValue = UILabel()
-        refillValue.text = "Launch volley"
-        refillValue.font = .systemFont(ofSize: 14, weight: .medium)
-        refillValue.textColor = Palette.primaryText
-
-        [title, done, styleCaption, cardsRow, dateCaption, picker, refillRow].forEach {
+        [title, done, styleCaption, cardsRow, dateCaption, picker, animationCaption, animationRows].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             content.addSubview($0)
-        }
-        [refillLabel, refillValue].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            refillRow.addSubview($0)
         }
 
         NSLayoutConstraint.activate([
@@ -173,16 +167,13 @@ final class SettingsSheetViewController: UIViewController {
             picker.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
             picker.heightAnchor.constraint(equalToConstant: 180),
 
-            refillRow.topAnchor.constraint(equalTo: picker.bottomAnchor, constant: 14),
-            refillRow.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
-            refillRow.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
-            refillRow.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -28),
+            animationCaption.topAnchor.constraint(equalTo: picker.bottomAnchor, constant: 14),
+            animationCaption.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
 
-            refillLabel.topAnchor.constraint(equalTo: refillRow.topAnchor, constant: 14),
-            refillLabel.bottomAnchor.constraint(equalTo: refillRow.bottomAnchor, constant: -14),
-            refillLabel.leadingAnchor.constraint(equalTo: refillRow.leadingAnchor, constant: 16),
-            refillValue.centerYAnchor.constraint(equalTo: refillLabel.centerYAnchor),
-            refillValue.trailingAnchor.constraint(equalTo: refillRow.trailingAnchor, constant: -16)
+            animationRows.topAnchor.constraint(equalTo: animationCaption.bottomAnchor, constant: 10),
+            animationRows.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
+            animationRows.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
+            animationRows.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -28)
         ])
     }
 
@@ -192,6 +183,34 @@ final class SettingsSheetViewController: UIViewController {
         label.textColor = Palette.tertiaryText
         label.setText(text, kern: 1.5)
         return label
+    }
+
+    private func animationRow(label: String, value: String) -> UIView {
+        let row = UIView()
+        row.backgroundColor = Palette.surface
+
+        let labelView = UILabel()
+        labelView.text = label
+        labelView.font = .systemFont(ofSize: 14)
+        labelView.textColor = Palette.secondaryText
+
+        let valueView = UILabel()
+        valueView.text = value
+        valueView.font = .systemFont(ofSize: 14, weight: .medium)
+        valueView.textColor = Palette.primaryText
+
+        [labelView, valueView].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            row.addSubview($0)
+        }
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: row.topAnchor, constant: 14),
+            labelView.bottomAnchor.constraint(equalTo: row.bottomAnchor, constant: -14),
+            labelView.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 16),
+            valueView.centerYAnchor.constraint(equalTo: labelView.centerYAnchor),
+            valueView.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -16)
+        ])
+        return row
     }
 
     private func refreshSelection() {

--- a/Countdown/TickDialView.swift
+++ b/Countdown/TickDialView.swift
@@ -13,6 +13,33 @@
 import UIKit
 import QuartzCore
 
+/// Animations a dial can play. Keeping the choice separate from the trigger
+/// lets taps use their own animation later without changing refill behavior.
+enum DialAnimation: String, CaseIterable {
+    case launchVolley
+
+    var title: String {
+        switch self {
+        case .launchVolley: return "Launch volley"
+        }
+    }
+}
+
+enum DialAnimationSettings {
+    /// The animation used when a ring fills on appear, rollover, or date edit.
+    static let refill: DialAnimation = .launchVolley
+
+    /// Persisted separately so a future picker can give taps a different
+    /// animation without coupling that choice to automatic refills.
+    static var tap: DialAnimation {
+        get {
+            let rawValue = UserDefaults.standard.string(forKey: "tapAnimation")
+            return rawValue.flatMap(DialAnimation.init(rawValue:)) ?? refill
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: "tapAnimation") }
+    }
+}
+
 /// Shared launch-volley math (also used by ConcentricDialView).
 enum Volley {
     /// Per-tick delay spread: `hash(i) × 420 ms`.
@@ -103,6 +130,10 @@ final class TickDialView: UIView {
     /// How much of the view the ring uses.
     var ringScale: CGFloat = 0.95 { didSet { setNeedsDisplay() } }
 
+    /// Animation played when this dial is tapped. This is intentionally
+    /// independent from automatic refill animation configuration.
+    var tapAnimation: DialAnimation = DialAnimationSettings.tap
+
     // MARK: - Value
 
     private(set) var value: Int = 0
@@ -137,6 +168,7 @@ final class TickDialView: UIView {
         backgroundColor = .clear
         isOpaque = false
         contentMode = .redraw
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapDial)))
     }
 
     deinit { link?.invalidate() }
@@ -152,10 +184,24 @@ final class TickDialView: UIView {
     /// to its slot on its own delay. Called automatically on rollover; call
     /// directly on appear or after a date change.
     func refill() {
+        play(DialAnimationSettings.refill)
+    }
+
+    private func startLaunchVolley() {
         guard window != nil else { volleyStart = nil; setNeedsDisplay(); return }
         volleyStart = CACurrentMediaTime()
         ensureLink()
         setNeedsDisplay()
+    }
+
+    @objc private func didTapDial() {
+        play(tapAnimation)
+    }
+
+    private func play(_ animation: DialAnimation) {
+        switch animation {
+        case .launchVolley: startLaunchVolley()
+        }
     }
 
     // MARK: - Display link


### PR DESCRIPTION
## Summary
- Add explicit dial animation types so tap and automatic refill behavior can diverge later without coupling them together.
- Replay the configured tap animation when either dial is tapped.
- Replace the old single refill row with a clearer animation section in the settings sheet.
- Preserve the current shipped behavior by keeping `Launch volley` as the active refill animation.

## Testing
- Not run (not requested)
- Validation is limited to code inspection of the animation routing and settings UI layout changes.